### PR TITLE
Add settimeout and re-raise KeyboardInterrupt (resolves #6)...

### DIFF
--- a/example_cdi_access.py
+++ b/example_cdi_access.py
@@ -45,6 +45,7 @@ if __name__ == "__main__":
 # endregion same code as other examples
 
 s = TcpSocket()
+# s.settimeout(30)
 s.connect(settings['host'], settings['port'])
 
 
@@ -106,7 +107,6 @@ def memoryReadSuccess(memo):
     this queues a new read until the entire CDI has been
     returned.  At that point, it invokes the XML processing below.
 
-
     Args:
         memo (_type_): _description_
     """
@@ -167,7 +167,7 @@ class MyHandler(xml.sax.handler.ContentHandler):
             print("  Atributes: ", attrs.getNames())
 
     def endElement(self, name):
-        print(name, "cpntent:", self._flushCharBuffer())
+        print(name, "content:", self._flushCharBuffer())
         print("End: ", name)
         pass
 

--- a/example_datagram_transfer.py
+++ b/example_datagram_transfer.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
 localNodeID = "05.01.01.01.03.01"
 farNodeID = "09.00.99.03.00.35"
 s = TcpSocket()
+# s.settimeout(30)
 s.connect(settings['host'], settings['port'])
 
 print("RR, SR are raw socket interface receive and send;"

--- a/example_frame_interface.py
+++ b/example_frame_interface.py
@@ -33,6 +33,7 @@ if __name__ == "__main__":
 # endregion same code as other examples
 
 s = TcpSocket()
+# s.settimeout(30)
 s.connect(settings['host'], settings['port'])
 
 print("RR, SR are raw socket interface receive and send;"

--- a/example_memory_transfer.py
+++ b/example_memory_transfer.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
 # endregion same code as other examples
 
 s = TcpSocket()
+# s.settimeout(30)
 s.connect(settings['host'], settings['port'])
 
 print("RR, SR are raw socket interface receive and send;"

--- a/example_message_interface.py
+++ b/example_message_interface.py
@@ -37,6 +37,7 @@ if __name__ == "__main__":
 # endregion same code as other examples
 
 s = TcpSocket()
+# s.settimeout(30)
 s.connect(settings['host'], settings['port'])
 
 print("RR, SR are raw socket interface receive and send; RL,"

--- a/example_node_implementation.py
+++ b/example_node_implementation.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
 # endregion same code as other examples
 
 s = TcpSocket()
+# s.settimeout(30)
 s.connect(settings['host'], settings['port'])
 
 print("RR, SR are raw socket interface receive and send;"

--- a/example_remote_nodes.py
+++ b/example_remote_nodes.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
 
 
 s = TcpSocket()
+# s.settimeout(30)
 s.connect(settings['host'], settings['port'])
 
 

--- a/example_string_interface.py
+++ b/example_string_interface.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
 
 
 s = TcpSocket()
+# s.settimeout(30)
 s.connect(settings['host'], settings['port'])
 
 #######################

--- a/example_tcp_message_interface.py
+++ b/example_tcp_message_interface.py
@@ -34,6 +34,7 @@ if __name__ == "__main__":
 # endregion same code as other examples
 
 s = TcpSocket()
+# s.settimeout(30)
 print("Using settings:")
 print(settings.dumps())
 s.connect(settings['host'], settings['port'])

--- a/openlcb/canbus/canframe.py
+++ b/openlcb/canbus/canframe.py
@@ -34,7 +34,6 @@ class CanFrame:
             alias = arg2
             self.header = (control << 12) | (alias & 0xFFF) | 0x10_000_000
             self.data = arg3
-
         else:
             print("could not decode NodeID ctor arguments")
 

--- a/openlcb/canbus/canlink.py
+++ b/openlcb/canbus/canlink.py
@@ -209,6 +209,8 @@ class CanLink(LinkLayer):
         try:
             del self.aliasToNodeID[alias]
             del self.nodeIdToAlias[nodeID]
+        except KeyboardInterrupt:
+            raise
         except:
             pass
 
@@ -221,6 +223,8 @@ class CanLink(LinkLayer):
         try:
             mapped = self.aliasToNodeID[frame.header & 0xFFF]
             sourceID = mapped
+        except KeyboardInterrupt:
+            raise
         except:
             #    special case for JMRI before 5.1.5 which sends
             #    VerifiedNodeID but not AMD
@@ -305,6 +309,8 @@ class CanLink(LinkLayer):
                 try:
                     mapped = self.aliasToNodeID[destAlias]
                     destID = mapped
+                except KeyboardInterrupt:
+                    raise
                 except:
                     destID = NodeID(self.nextInternallyAssignedNodeID)
                     logging.warning("message from unknown dest alias:"
@@ -370,6 +376,8 @@ class CanLink(LinkLayer):
             try:
                 sssAlias = self.nodeIdToAlias[msg.source]
                 header |= ((sssAlias) & 0xFFF)
+            except KeyboardInterrupt:
+                raise
             except:
                 logging.warning(
                     "Did not know source = {} on datagram send"
@@ -379,6 +387,8 @@ class CanLink(LinkLayer):
             try:
                 dddAlias = self.nodeIdToAlias[msg.destination]
                 header |= ((dddAlias) & 0xFFF) << 12
+            except KeyboardInterrupt:
+                raise
             except:
                 logging.warning(
                     "Did not know destination = {} on datagram send"
@@ -581,6 +591,8 @@ class CanLink(LinkLayer):
         try:
             retval = ControlFrame((frame.header >> 12) & 0x2FFFF)
             return retval  # top 1 bit for out-of-band messages
+        except KeyboardInterrupt:
+            raise
         except:
             logging.warning("Could not decode header 0x{:08X}"
                             "".format(frame.header))

--- a/openlcb/canbus/tcpsocket.py
+++ b/openlcb/canbus/tcpsocket.py
@@ -14,6 +14,15 @@ class TcpSocket:
         else:
             self.sock = sock
 
+    def settimeout(self, seconds):
+        """Set the timeout for connect and transfer.
+
+        Args:
+            seconds (float): The number of seconds to wait before
+                a timeout error occurs.
+        """
+        self.sock.settimeout(seconds)
+
     def connect(self, host, port):
         self.sock.connect((host, port))
 

--- a/openlcb/datagramservice.py
+++ b/openlcb/datagramservice.py
@@ -106,6 +106,8 @@ class DatagramService:
             return DatagramService.ProtocolID.Unrecognized
         try:
             retval = DatagramService.ProtocolID(data[0])
+        except KeyboardInterrupt:
+            raise
         except:
             return DatagramService.ProtocolID.Unrecognized
         if retval is not None:

--- a/openlcb/memoryservice.py
+++ b/openlcb/memoryservice.py
@@ -313,6 +313,8 @@ class MemoryService:
         try:
             temp = data.index(0)
             zeroIndex = temp
+        except KeyboardInterrupt:
+            raise
         except:
             pass
 

--- a/openlcb/tcplink/tcpsocket.py
+++ b/openlcb/tcplink/tcpsocket.py
@@ -16,6 +16,15 @@ class TcpSocket:
         else:
             self.sock = sock
 
+    def settimeout(self, seconds):
+        """Set the timeout for connect and transfer.
+
+        Args:
+            seconds (float): The number of seconds to wait before
+                a timeout error occurs.
+        """
+        self.sock.settimeout(seconds)
+
     def connect(self, host, port):
         self.sock.connect((host, port))
 


### PR DESCRIPTION
Expose the underlying socket settimeout method in TcpSocket to mimic socket's standard behavior (and re-raise KeyboardInterrupt) to allow an application to circumvent blocking io on the same thread.