### PR TITLE
Change to https for URLs and mark an optional dependency for the example GUI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A Python implementation of [OpenLCB](http://www.openlcb.org)/[LCC](https://www.nmra.org/lcc) based on the [LccTools](https://apps.apple.com/sr/app/lcctools/id1640295587) app's [Swift implementation](https://github.com/bobjacobsen/OpenlcbLibrary) as of January 2024.
+A Python implementation of [OpenLCB](https://www.openlcb.org)/[LCC](https://www.nmra.org/lcc) based on the [LccTools](https://apps.apple.com/sr/app/lcctools/id1640295587) app's [Swift implementation](https://github.com/bobjacobsen/OpenlcbLibrary) as of January 2024.
 
 Requires Python 3.8 or later.
 

--- a/examples_gui.py
+++ b/examples_gui.py
@@ -309,7 +309,7 @@ class MainForm(ttk.Frame):
             command_text="Default",
             tooltip=('("05.01.01.01.03.01 for Python openlcb examples only:'),
         )
-        self.unique_ranges_url = "http://registry.openlcb.org/uniqueidranges"
+        self.unique_ranges_url = "https://registry.openlcb.org/uniqueidranges"
         underlined_url = \
             ''.join([letter+'\u0332' for letter in self.unique_ranges_url])
         # ^ '\u0332' is unicode for "underline previous character"

--- a/examples_settings.py
+++ b/examples_settings.py
@@ -32,7 +32,7 @@ SETTINGS_COMMENTS = {
         "Warning: *only for openlcb*:"
         " 05.01.01.01.03.01 is reserved by OpenLCB Python examples."
         " Find or suggest your organization's range"
-        " at http://registry.openlcb.org/uniqueidranges"
+        " at https://registry.openlcb.org/uniqueidranges"
         " and serialize if producing hardware (See LCC Standard(s))."
     ),
     "farNodeID_comment": (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,10 @@ requires-python = ">= 3.8"
 # dependencies = [
 # ]
 
+[project.optional-dependencies]
+gui = ["zeroconf"]
+# ^ GUI uses zeroconf for a drop-down to select an TCP/IP device if any advertise an openlcb-can service.
+
 [project.urls]
 # List of names: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
 Repository = "https://github.com/bobjacobsen/PythonOlcbNode"


### PR DESCRIPTION
- Change http to https to prevent browser warnings.
- (pyproject.toml) zeroconf can be marked as optional and GUI-only in this case.