### PR TITLE
Update the git URL.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,7 +179,7 @@ cython_debug/
 /*.bad_json.txt
 /settings.json
 /.vscode/settings.json
-# ^ /.vscode/settings.json is ignored since it may have python.defaultInterpreterPath with differs depending on the specific machine. Recommended: place that setting in there ("PythonOlcbNode Folder" tab in VSCode settings)
+# ^ /.vscode/settings.json is ignored since it may have python.defaultInterpreterPath with differs depending on the specific machine. Recommended: place that setting in there ("python-openlcb Folder" tab in VSCode settings)
 /build
 /doc/_autosummary
 /examples/settings.json

--- a/examples/example_node_implementation.py
+++ b/examples/example_node_implementation.py
@@ -108,7 +108,7 @@ def memoryReadFail(memo):
 # protocols
 localNode = Node(
     NodeID(settings['localNodeID']),
-    SNIP("PythonOlcbNode", "example_node_implementation",
+    SNIP("python-openlcb", "example_node_implementation",
          "0.1", "0.2", "User Name Here", "User Description Here"),
     set([PIP.SIMPLE_NODE_IDENTIFICATION_PROTOCOL, PIP.DATAGRAM_PROTOCOL])
 )

--- a/examples/example_remote_nodes.py
+++ b/examples/example_remote_nodes.py
@@ -84,7 +84,7 @@ canLink.registerMessageReceivedListener(printMessage)
 # protocols
 localNode = Node(
     NodeID(settings['localNodeID']),
-    SNIP("PythonOlcbNode", "example_node_implementation",
+    SNIP("python-openlcb", "example_node_implementation",
          "0.1", "0.2", "User Name Here", "User Description Here"),
     set([PIP.SIMPLE_NODE_IDENTIFICATION_PROTOCOL, PIP.DATAGRAM_PROTOCOL])
 )

--- a/examples/examples_gui.py
+++ b/examples/examples_gui.py
@@ -1,8 +1,8 @@
 """
 Examples GUI
 
-This file is part of the PythonOlcbNode project
-(<https://github.com/bobjacobsen/PythonOlcbNode>).
+This file is part of the python-openlcb project
+(<https://github.com/bobjacobsen/python-openlcb>).
 
 Contributors: Poikilos
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ gui = ["zeroconf"]
 
 [project.urls]
 # List of names: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
-Repository = "https://github.com/bobjacobsen/PythonOlcbNode"
-Issues = "https://github.com/bobjacobsen/PythonOlcbNode/issues"
-# Changelog = "https://github.com/bobjacobsen/PythonOlcbNode/blob/master/CHANGELOG.md"
+Repository = "https://github.com/bobjacobsen/python-openlcb"
+Issues = "https://github.com/bobjacobsen/python-openlcb/issues"
+# Changelog = "https://github.com/bobjacobsen/python-openlcb/blob/master/CHANGELOG.md"
 # ^ TODO: Uncomment this if a changelog is added (& change url to match case).
 #   - For a common way to use markdown for it see: https://keepachangelog.com/en/1.1.0/


### PR DESCRIPTION
I noticed the old URL was still referenced, and the old project name was still used for the SNIP constructor. Hopefully this change is correct (Review my changes to SNIP constructor calls).